### PR TITLE
Update to CRS 4.0 and adjust default WAF rules

### DIFF
--- a/charts/codesealer/Chart.yaml
+++ b/charts/codesealer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/codesealer/templates/configmap-crs-setup.yaml
+++ b/charts/codesealer/templates/configmap-crs-setup.yaml
@@ -12,10 +12,11 @@ metadata:
 data:
   crs-setup.conf: |
     # ------------------------------------------------------------------------
-    # OWASP ModSecurity Core Rule Set ver.3.3.2
+    # OWASP CRS ver.4.0.0
     # Copyright (c) 2006-2020 Trustwave and contributors. All rights reserved.
+    # Copyright (c) 2021-2024 CRS project. All rights reserved.
     #
-    # The OWASP ModSecurity Core Rule Set is distributed under
+    # The OWASP CRS is distributed under
     # Apache Software License (ASL) version 2
     # Please see the enclosed LICENSE file for full details.
     # ------------------------------------------------------------------------
@@ -24,15 +25,15 @@ data:
     #
     # -- [[ Introduction ]] --------------------------------------------------------
     #
-    # The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack
+    # The OWASP CRS is a set of generic attack
     # detection rules that provide a base level of protection for any web
     # application. They are written for the open source, cross-platform
     # ModSecurity Web Application Firewall.
     #
     # See also:
     # https://coreruleset.org/
-    # https://github.com/SpiderLabs/owasp-modsecurity-crs
-    # https://www.owasp.org/index.php/Category:OWASP_ModSecurity_Core_Rule_Set_Project
+    # https://github.com/coreruleset/coreruleset
+    # https://owasp.org/www-project-modsecurity-core-rule-set/
     #
 
 
@@ -187,12 +188,12 @@ data:
     # Uncomment this rule to change the default:
     #
     SecAction \
-     "id:900000,\
-      phase:1,\
-      nolog,\
-      pass,\
-      t:none,\
-      setvar:tx.paranoia_level={{ .Values.worker.config.modsecurity.crs.paranoiaLevel }}"
+        "id:900000,\
+        phase:1,\
+        pass,\
+        t:none,\
+        nolog,\
+        setvar:tx.blocking_paranoia_level={{ .Values.worker.waf.crs.blocking_paranoia_level }}"
 
 
     # It is possible to execute rules from a higher paranoia level but not include
@@ -201,24 +202,24 @@ data:
     # the new rules would lead to false positives that raise your score above the
     # threshold.
     # This optional feature is enabled by uncommenting the following rule and
-    # setting the tx.executing_paranoia_level.
-    # Technically, rules up to the level defined in tx.executing_paranoia_level
-    # will be executed, but only the rules up to tx.paranoia_level affect the
+    # setting the tx.detection_paranoia_level.
+    # Technically, rules up to the level defined in tx.detection_paranoia_level
+    # will be executed, but only the rules up to tx.blocking_paranoia_level affect the
     # anomaly scores.
-    # By default, tx.executing_paranoia_level is set to tx.paranoia_level.
-    # tx.executing_paranoia_level must not be lower than tx.paranoia_level.
+    # By default, tx.detection_paranoia_level is set to tx.blocking_paranoia_level.
+    # tx.detection_paranoia_level must not be lower than tx.blocking_paranoia_level.
     #
-    # Please notice that setting tx.executing_paranoia_level to a higher paranoia
+    # Please notice that setting tx.detection_paranoia_level to a higher paranoia
     # level results in a performance impact that is equally high as setting
-    # tx.paranoia_level to said level.
+    # tx.blocking_paranoia_level to said level.
     #
     SecAction \
-     "id:900001,\
-      phase:1,\
-      nolog,\
-      pass,\
-      t:none,\
-      setvar:tx.executing_paranoia_level={{ .Values.worker.config.modsecurity.crs.executing_paranoia_level }}"
+        "id:900001,\
+        phase:1,\
+        pass,\
+        t:none,\
+        nolog,\
+        setvar:tx.detection_paranoia_level={{ .Values.worker.waf.crs.detection_paranoia_level }}"
 
 
     #
@@ -237,16 +238,16 @@ data:
     # Uncomment this rule to change the default:
     #
     SecAction \
-     "id:900010,\
-      phase:1,\
-      nolog,\
-      pass,\
-      t:none,\
-      setvar:tx.enforce_bodyproc_urlencoded={{ .Values.worker.config.modsecurity.crs.enforce_bodyproc_urlencoded }}"
+        "id:900010,\
+        phase:1,\
+        pass,\
+        t:none,\
+        nolog,\
+        setvar:tx.enforce_bodyproc_urlencoded={{ .Values.worker.waf.crs.enforce_bodyproc_urlencoded }}"
 
 
     #
-    # -- [[ Anomaly Mode Severity Levels ]] ----------------------------------------
+    # -- [[ Anomaly Scoring Mode Severity Levels ]] --------------------------------
     #
     # Each rule in the CRS has an associated severity level.
     # These are the default scoring points for each severity level.
@@ -270,19 +271,19 @@ data:
     # that all configuration variables are set before the CRS rules are processed.)
     #
     SecAction \
-    "id:900100,\
-     phase:1,\
-     nolog,\
-     pass,\
-     t:none,\
-     setvar:tx.critical_anomaly_score={{ .Values.worker.config.modsecurity.crs.critical_anomaly_score }},\
-     setvar:tx.error_anomaly_score={{ .Values.worker.config.modsecurity.crs.error_anomaly_score }},\
-     setvar:tx.warning_anomaly_score={{ .Values.worker.config.modsecurity.crs.warning_anomaly_score }},\
-     setvar:tx.notice_anomaly_score={{ .Values.worker.config.modsecurity.crs.notice_anomaly_score }}"
+        "id:900100,\
+        phase:1,\
+        pass,\
+        t:none,\
+        nolog,\
+        setvar:tx.critical_anomaly_score={{ .Values.worker.waf.crs.critical_anomaly_score }},\
+        setvar:tx.error_anomaly_score={{ .Values.worker.waf.crs.error_anomaly_score }},\
+        setvar:tx.warning_anomaly_score={{ .Values.worker.waf.crs.warning_anomaly_score }},\
+        setvar:tx.notice_anomaly_score={{ .Values.worker.waf.crs.notice_anomaly_score }}"
 
 
     #
-    # -- [[ Anomaly Mode Blocking Threshold Levels ]] ------------------------------
+    # -- [[ Anomaly Scoring Mode Blocking Threshold Levels ]] ----------------------
     #
     # Here, you can specify at which cumulative anomaly score an inbound request,
     # or outbound response, gets blocked.
@@ -322,57 +323,121 @@ data:
     # Uncomment this rule to change the defaults:
     #
     SecAction \
-    "id:900110,\
-     phase:1,\
-     nolog,\
-     pass,\
-     t:none,\
-     setvar:tx.inbound_anomaly_score_threshold={{ .Values.worker.config.modsecurity.crs.inbound_anomaly_score_threshold }},\
-     setvar:tx.outbound_anomaly_score_threshold={{ .Values.worker.config.modsecurity.crs.outbound_anomaly_score_threshold }}"
+        "id:900110,\
+        phase:1,\
+        pass,\
+        t:none,\
+        nolog,\
+        setvar:tx.inbound_anomaly_score_threshold={{ .Values.worker.waf.crs.inbound_anomaly_score_threshold }},\
+        setvar:tx.outbound_anomaly_score_threshold={{ .Values.worker.waf.crs.outbound_anomaly_score_threshold }}"
+
 
     #
-    # -- [[ Application Specific Rule Exclusions ]] ----------------------------------------
+    # -- [[ Application Specific Rule Exclusions ]] --------------------------------
     #
-    # Some well-known applications may undertake actions that appear to be
-    # malicious. This includes actions such as allowing HTML or Javascript within
-    # parameters. In such cases the CRS aims to prevent false positives by allowing
-    # administrators to enable prebuilt, application specific exclusions on an
-    # application by application basis.
-    # These application specific exclusions are distinct from the rules that would
-    # be placed in the REQUEST-900-EXCLUSION-RULES-BEFORE-CRS configuration file as
-    # they are prebuilt for specific applications. The 'REQUEST-900' file is
-    # designed for users to add their own custom exclusions. Note, using these
-    # application specific exclusions may loosen restrictions of the CRS,
-    # especially if used with an application they weren't designed for. As a result
-    # they should be applied with care.
-    # To use this functionality you must specify a supported application. To do so
-    # uncomment rule 900130. In addition to uncommenting the rule you will need to
-    # specify which application(s) you'd like to enable exclusions for. Only a
-    # (very) limited set of applications are currently supported, please use the
-    # filenames prefixed with 'REQUEST-903' to guide you in your selection.
-    # Such filenames use the following convention:
-    # REQUEST-903.9XXX-{APPNAME}-EXCLUSIONS-RULES.conf
+    # CRS 3.x contained exclusion packages to tweak the CRS for use with common
+    # web applications, lowering the number of false positives.
     #
-    # It is recommended if you run multiple web applications on your site to limit
-    # the effects of the exclusion to only the path where the excluded webapp
-    # resides using a rule similar to the following example:
-    # SecRule REQUEST_URI "@beginsWith /wordpress/" setvar:tx.crs_exclusions_wordpress=1
+    # In CRS 4, these are no longer part of the CRS itself, but they are available
+    # as "CRS plugins". Some plugins improve support for web applications, and others
+    # may bring new functionality. Plugins are not installed by default, but can be
+    # downloaded from the plugin registry:
+    # https://github.com/coreruleset/plugin-registry
+    #
+    # For detailed information about using and installing plugins, please see:
+    # https://coreruleset.org/docs/concepts/plugins/
+
 
     #
-    # Modify and uncomment this rule to select which application:
+    # -- [[ Anomaly Score Reporting Level ]] ---------------------------------------
+    #
+    # When a request is blocked due to the anomaly score meeting or exceeding the
+    # anomaly threshold then the blocking rule will also report the anomaly score.
+    # This applies to the separate inbound and outbound anomaly scores.
+    #
+    # In phase 5, there are additional rules that can perform additional reporting
+    # of anomaly scores with a verbosity that depends on the reporting level defined
+    # below.
+    #
+    # By setting the reporting level you control whether you want additional
+    # reporting beyond the blocking rule or not and, if yes, which requests should
+    # be covered. The higher the reporting level, the more verbose the reporting is.
+    #
+    # There are 6 reporting levels:
+    #
+    # 0 - Reporting disabled
+    # 1 - Reporting for requests with a blocking anomaly score >= a threshold
+    # 2 - Reporting for requests with a detection anomaly score >= a threshold
+    # 3 - Reporting for requests with a blocking anomaly score greater than 0
+    # 4 - Reporting for requests with a detection anomaly score greater than 0
+    # 5 - Reporting for all requests
+    #
+    # Note: Reporting levels 1 and 2 make it possible to differentiate between
+    # requests that are blocked and requests that are *not* blocked but would have
+    # been blocked if the blocking PL was equal to detection PL. This may be useful
+    # for certain FP tuning methodologies, for example moving to a higher PL.
+    #
+    # A value of 5 can be useful on platforms where you are interested in logging
+    # non-scoring requests, yet it is not possible to report this information in
+    # the request/access log. This applies to Nginx, for example.
     #
     #SecAction \
-    # "id:900130,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.crs_exclusions_cpanel=1,\
-    #  setvar:tx.crs_exclusions_drupal=1,\
-    #  setvar:tx.crs_exclusions_dokuwiki=1,\
-    #  setvar:tx.crs_exclusions_nextcloud=1,\
-    #  setvar:tx.crs_exclusions_wordpress=1,\
-    #  setvar:tx.crs_exclusions_xenforo=1"
+    #    "id:900115,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.reporting_level=4"
+
+
+    #
+    # -- [[ Early Anomaly Scoring Mode Blocking ]] ------------------------------
+    #
+    # The anomaly scores for the request and the responses are generally summed up
+    # and evaluated at the end of phase:2 and at the end of phase:4 respectively.
+    # However, it is possible to enable an early evaluation of these anomaly scores
+    # at the end of phase:1 and at the end of phase:3.
+    #
+    # If a request (or a response) hits the anomaly threshold in this early
+    # evaluation, then blocking happens immediately (if blocking is enabled) and
+    # the phase 2 (and phase 4 respectively) will no longer be executed.
+    #
+    # Enable the rule 900120 that sets the variable tx.early_blocking to 1 in order
+    # to enable early blocking. The variable tx.early_blocking is set to 0 by
+    # default. Early blocking is thus disabled by default.
+    #
+    # Please note that early blocking will hide potential alerts from you. This
+    # means that a payload that would appear in an alert in phase 2 (or phase 4)
+    # does not get evaluated if the request is being blocked early. So when you
+    # disabled early blocking again at some point in the future, then new alerts
+    # from phase 2 might pop up.
+    #SecAction \
+    #    "id:900120,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.early_blocking=1"
+
+
+    #
+    # -- [[ Initialize Default Collections ]] -----------------------------------
+    #
+    # CRS provides a centralized option to initialize and populate collections
+    # meant to be used by plugins (E.g.DoS protection plugin).
+    # By default, Global and IP collections (see rule 901320),
+    # being not used by core rules, are not initialized.
+    #
+    # Uncomment this rule to change the default:
+    #
+    #SecAction \
+    #    "id:900130,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.enable_default_collections=1"
+
 
     #
     # -- [[ HTTP Policy Settings ]] ------------------------------------------------
@@ -383,7 +448,6 @@ data:
     #
     # These variables are used in the following rule files:
     # - REQUEST-911-METHOD-ENFORCEMENT.conf
-    # - REQUEST-912-DOS-PROTECTION.conf
     # - REQUEST-920-PROTOCOL-ENFORCEMENT.conf
 
     # HTTP methods that a client is allowed to use.
@@ -392,93 +456,168 @@ data:
     # Example: for WebDAV, add the following methods: CHECKOUT COPY DELETE LOCK
     #          MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH PUT UNLOCK
     # Uncomment this rule to change the default.
-    #SecAction \
-    # "id:900200,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
+    SecAction \
+     "id:900200,\
+      phase:1,\
+      nolog,\
+      pass,\
+      t:none,\
+      setvar:'tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE'"
 
     # Content-Types that a client is allowed to send in a request.
     # Default: |application/x-www-form-urlencoded| |multipart/form-data| |multipart/related|
-    # |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json|
-    # |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream|
-    # |application/csp-report| |application/xss-auditor-report| |text/plain|
+    # |text/xml| |application/xml| |application/soap+xml| |application/json|
+    # |application/cloudevents+json| |application/cloudevents-batch+json|
+    #
+    # Please note, that the rule where CRS uses this variable (920420) evaluates it with operator
+    # `@within`, which is case sensitive, but uses t:lowercase. You must add your whole custom
+    # Content-Type with lowercase.
+    #
+    # Bypass Warning: some applications may not rely on the content-type request header in order
+    # to parse the request body. This could make an attacker able to send malicious URLENCODED/JSON/XML
+    # payloads without being detected by the WAF. Allowing request content-type that doesn't activate any
+    # body processor (for example: "text/plain", "application/x-amf", "application/octet-stream", etc..)
+    # could lead to a WAF bypass. For example, a malicious JSON payload submitted with a "text/plain"
+    # content type may still be interpreted as JSON by a backend application but would not trigger the
+    # JSON body parser at the WAF, leading to a bypass.
+    #
+    # To prevent blocking request with not allowed content-type by default, you can create an exclusion
+    # rule that removes rule 920420. For example:
+    #SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain" \
+    #    "id:1234,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    ctl:ruleRemoveById=920420,\
+    #    chain"
+    #    SecRule REQUEST_URI "@rx ^/foo/bar" \
+    #        "t:none"
+    #
     # Uncomment this rule to change the default.
+    #
     #SecAction \
-    # "id:900220,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream| |application/csp-report| |application/xss-auditor-report| |text/plain|'"
+    #    "id:900220,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
 
     # Allowed HTTP versions.
-    # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0
-    # Example for legacy clients: HTTP/0.9 HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0
+    # Default: HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0
+    # Example for legacy clients: HTTP/0.9 HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0
     # Note that some web server versions use 'HTTP/2', some 'HTTP/2.0', so
     # we include both version strings by default.
     # Uncomment this rule to change the default.
     #SecAction \
-    # "id:900230,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0'"
+    #    "id:900230,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:'tx.allowed_http_versions=HTTP/1.0 HTTP/1.1 HTTP/2 HTTP/2.0 HTTP/3 HTTP/3.0'"
 
     # Forbidden file extensions.
     # Guards against unintended exposure of development/configuration files.
-    # Default: .asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/
+    # Default: .asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/
     # Example: .bak/ .config/ .conf/ .db/ .ini/ .log/ .old/ .pass/ .pdb/ .rdb/ .sql/
+    # Note that .axd was removed due to false positives (see PR 1925).
+    #
+    # To additionally guard against configuration/install archive files from being
+    # accidentally exposed, common archive file extensions can be added to the
+    # restricted extensions list. An example list of common archive file extensions
+    # is presented below:
+    # .7z/ .br/ .bz/ .bz2/ .cab/ .cpio/ .gz/ .img/ .iso/ .jar/ .rar/ .tar/ .tbz2/ .tgz/ .txz/ .xz/ .zip/ .zst/
+    # (Source: https://en.wikipedia.org/wiki/List_of_archive_formats)
+    #
     # Uncomment this rule to change the default.
     #SecAction \
-    # "id:900240,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
+    #    "id:900240,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:'tx.restricted_extensions=.asa/ .asax/ .ascx/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .rdb/ .resources/ .resx/ .sql/ .swp/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'"
 
-    # Forbidden request headers.
-    # Header names should be lowercase, enclosed by /slashes/ as delimiters.
-    # Blocking Proxy header prevents 'httpoxy' vulnerability: https://httpoxy.org
-    # Default: /proxy/ /lock-token/ /content-range/ /if/
+    # Restricted request headers.
+    # The HTTP request headers that CRS restricts are split into two categories:
+    # basic (always forbidden) and extended (may be forbidden). All header names
+    # should be lowercase and enclosed by /slashes/ as delimiters.
+    #
+    # [ Basic ]
+    # Includes deprecated headers and headers with known security risks. Always
+    # forbidden.
+    # Default: /content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/
+    #
+    # /content-encoding/
+    #   Used to list any encodings that have been applied to the original payload.
+    #   Only used for compression, which isn't supported by CRS by default since CRS
+    #   blocks newlines and null bytes inside the request body. Most compression
+    #   algorithms require at least null bytes per RFC. Blocking Content-Encoding
+    #   shouldn't break anything and increases security since WAF engines, including
+    #   ModSecurity, are typically incapable of properly scanning compressed request
+    #   bodies.
+    #
+    # /proxy/
+    #   Blocking this prevents the 'httpoxy' vulnerability: https://httpoxy.org
+    #
+    # /lock-token/
+    #
+    # /content-range/
+    #
+    # /if/
+    #
+    # /x-http-method-override/
+    # /x-http-method/
+    # /x-method-override/
+    #   Blocking these headers prevents method override attacks, as described here:
+    #   https://www.sidechannel.blog/en/http-method-override-what-it-is-and-how-a-pentester-can-use-it
+    #
     # Uncomment this rule to change the default.
     #SecAction \
-    # "id:900250,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.restricted_headers=/proxy/ /lock-token/ /content-range/ /if/'"
-
-    # File extensions considered static files.
-    # Extensions include the dot, lowercase, enclosed by /slashes/ as delimiters.
-    # Used in DoS protection rule. See section "Anti-Automation / DoS Protection".
-    # Default: /.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/
+    #    "id:900250,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:'tx.restricted_headers_basic=/content-encoding/ /proxy/ /lock-token/ /content-range/ /if/ /x-http-method-override/ /x-http-method/ /x-method-override/'"
+    #
+    # [ Extended ]
+    # Includes deprecated headers that are still in use (so false positives are
+    # possible) and headers with possible security risks. Forbidden at a higher
+    # paranoia level.
+    # Default: /accept-charset/
+    #
+    # /accept-charset/
+    #   Deprecated header that should not be used by clients and should be ignored
+    #   by servers. Can be used for a response WAF bypass by asking for a charset
+    #   that the WAF cannot decode. Considered to be a good indicator of suspicious
+    #   behavior but produces too many false positives to be forbidden by default.
+    #   References:
+    #   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Charset
+    #   https://github.com/coreruleset/coreruleset/issues/3140
+    #
     # Uncomment this rule to change the default.
     #SecAction \
-    # "id:900260,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.static_extensions=/.jpg/ /.jpeg/ /.png/ /.gif/ /.js/ /.css/ /.ico/ /.svg/ /.webp/'"
+    #    "id:900255,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:'tx.restricted_headers_extended=/accept-charset/'"
 
     # Content-Types charsets that a client is allowed to send in a request.
-    # Default: utf-8|iso-8859-1|iso-8859-15|windows-1252
+    # The content-types are enclosed by |pipes| as delimiters to guarantee exact matches.
+    # Default: |utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|
     # Uncomment this rule to change the default.
-    # Use "|" to separate multiple charsets like in the rule defining
-    # tx.allowed_request_content_type.
     #SecAction \
-    # "id:900280,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.allowed_request_content_type_charset=utf-8|iso-8859-1|iso-8859-15|windows-1252'"
+    #    "id:900280,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:'tx.allowed_request_content_type_charset=|utf-8| |iso-8859-1| |iso-8859-15| |windows-1252|'"
 
     #
     # -- [[ HTTP Argument/Upload Limits ]] -----------------------------------------
@@ -493,80 +632,82 @@ data:
     # Block request if number of arguments is too high
     # Default: unlimited
     # Example: 255
+    # Note that a hard limit by the engine may also apply here (SecArgumentsLimit).
+    # This would override this soft limit.
     # Uncomment this rule to set a limit.
     #SecAction \
-    # "id:900300,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.max_num_args=255"
+    #    "id:900300,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.max_num_args=255"
 
     # Block request if the length of any argument name is too high
     # Default: unlimited
     # Example: 100
     # Uncomment this rule to set a limit.
     #SecAction \
-    # "id:900310,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.arg_name_length=100"
+    #    "id:900310,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.arg_name_length=100"
 
     # Block request if the length of any argument value is too high
     # Default: unlimited
     # Example: 400
     # Uncomment this rule to set a limit.
     #SecAction \
-    # "id:900320,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.arg_length=400"
+    #    "id:900320,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.arg_length=400"
 
     # Block request if the total length of all combined arguments is too high
     # Default: unlimited
     # Example: 64000
     # Uncomment this rule to set a limit.
     #SecAction \
-    # "id:900330,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.total_arg_length=64000"
+    #    "id:900330,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.total_arg_length=64000"
 
     # Block request if the file size of any individual uploaded file is too high
     # Default: unlimited
     # Example: 1048576
     # Uncomment this rule to set a limit.
     #SecAction \
-    # "id:900340,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.max_file_size=1048576"
+    #    "id:900340,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.max_file_size=1048576"
 
     # Block request if the total size of all combined uploaded files is too high
     # Default: unlimited
     # Example: 1048576
     # Uncomment this rule to set a limit.
     #SecAction \
-    # "id:900350,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.combined_file_sizes=1048576"
+    #    "id:900350,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.combined_file_sizes=1048576"
 
 
     #
     # -- [[ Easing In / Sampling Percentage ]] -------------------------------------
     #
-    # Adding the Core Rule Set to an existing productive site can lead to false
+    # Adding the CRS to an existing productive site can lead to false
     # positives, unexpected performance issues and other undesired side effects.
     #
     # It can be beneficial to test the water first by enabling the CRS for a
@@ -585,7 +726,7 @@ data:
     # following directive somewhere after the inclusion of the CRS
     # (E.g., RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf).
     #
-    # SecRuleUpdateActionById 901150 "nolog"
+    #SecRuleUpdateActionById 901450 "nolog"
     #
     # ATTENTION: If this TX.sampling_percentage is below 100, then some of the
     # requests will bypass the Core Rules completely and you lose the ability to
@@ -593,147 +734,13 @@ data:
     #
     # Uncomment this rule to enable this feature:
     #
-    #SecAction "id:900400,\
-    #  phase:1,\
-    #  pass,\
-    #  nolog,\
-    #  setvar:tx.sampling_percentage=100"
-
-
-    #
-    # -- [[ Project Honey Pot HTTP Blacklist ]] ------------------------------------
-    #
-    # Optionally, you can check the client IP address against the Project Honey Pot
-    # HTTPBL (dnsbl.httpbl.org). In order to use this, you need to register to get a
-    # free API key. Set it here with SecHttpBlKey.
-    #
-    # Project Honeypot returns multiple different malicious IP types.
-    # You may specify which you want to block by enabling or disabling them below.
-    #
-    # Ref: https://www.projecthoneypot.org/httpbl.php
-    # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecHttpBlKey
-    #
-    # Uncomment these rules to use this feature:
-    #
-    #SecHttpBlKey XXXXXXXXXXXXXXXXX
-    #SecAction "id:900500,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.block_search_ip=1,\
-    #  setvar:tx.block_suspicious_ip=1,\
-    #  setvar:tx.block_harvester_ip=1,\
-    #  setvar:tx.block_spammer_ip=1"
-
-
-    #
-    # -- [[ GeoIP Database ]] ------------------------------------------------------
-    #
-    # There are some rulesets that inspect geolocation data of the client IP address
-    # (geoLookup). The CRS uses geoLookup to implement optional country blocking.
-    #
-    # To use geolocation, we make use of the MaxMind GeoIP database.
-    # This database is not included with the CRS and must be downloaded.
-    #
-    # There are two formats for the GeoIP database. ModSecurity v2 uses GeoLite (.dat files),
-    # and ModSecurity v3 uses GeoLite2 (.mmdb files).
-    #
-    # If you use ModSecurity 3, MaxMind provides a binary for updating GeoLite2 files,
-    # see https://github.com/maxmind/geoipupdate.
-    #
-    # Download the package for your OS, and read https://dev.maxmind.com/geoip/geoipupdate/
-    # for configuration options.
-    #
-    # Warning: GeoLite (not GeoLite2) databases are considered legacy, and not being updated anymore.
-    # See https://support.maxmind.com/geolite-legacy-discontinuation-notice/ for more info.
-    #
-    # Therefore, if you use ModSecurity v2, you need to regenerate updated .dat files
-    # from CSV files first.
-    #
-    # You can achieve this using https://github.com/sherpya/geolite2legacy
-    # Pick the zip files from maxmind site:
-    # https://geolite.maxmind.com/download/geoip/database/GeoLite2-Country-CSV.zip
-    #
-    # Follow the guidelines for installing the tool and run:
-    # ./geolite2legacy.py -i GeoLite2-Country-CSV.zip \
-    #                     -f geoname2fips.csv -o /usr/share/GeoliteCountry.dat
-    #
-    # Update the database regularly, see Step 3 of the configuration link above.
-    #
-    # By default, when you execute `sudo geoipupdate` on Linux, files from the free database
-    # will be downloaded to `/usr/share/GeoIP` (both v1 and v2).
-    #
-    # Then choose from:
-    #   - `GeoLite2-Country.mmdb` (if you are using ModSecurity v3)
-    #   - `GeoLiteCountry.dat`    (if you are using ModSecurity v2)
-    #
-    # Ref: http://blog.spiderlabs.com/2010/10/detecting-malice-with-modsecurity-geolocation-data.html
-    # Ref: http://blog.spiderlabs.com/2010/11/detecting-malice-with-modsecurity-ip-forensics.html
-    #
-    # Uncomment only one of the next rules here to use this feature.
-    # Choose the one depending on the ModSecurity version you are using, and change the path accordingly:
-    #
-    # For ModSecurity v3:
-    #SecGeoLookupDB /usr/share/GeoIP/GeoLite2-Country.mmdb
-    # For ModSecurity v2 (points to the converted one):
-    #SecGeoLookupDB /usr/share/GeoIP/GeoLiteCountry.dat
-
-    #
-    # -=[ Block Countries ]=-
-    #
-    # Rules in the IP Reputation file can check the client against a list of high
-    # risk country codes. These countries have to be defined in the variable
-    # tx.high_risk_country_codes via their ISO 3166 two-letter country code:
-    # https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements
-    #
-    # If you are sure that you are not getting any legitimate requests from a given
-    # country, then you can disable all access from that country via this variable.
-    # The rule performing the test has the rule id 910100.
-    #
-    # This rule requires SecGeoLookupDB to be enabled and the GeoIP database to be
-    # downloaded (see the section "GeoIP Database" above.)
-    #
-    # By default, the list is empty. A list used by some sites was the following:
-    # setvar:'tx.high_risk_country_codes=UA ID YU LT EG RO BG TR RU PK MY CN'"
-    #
-    # Uncomment this rule to use this feature:
-    #
-    # SecAction \
-    # "id:900600,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.high_risk_country_codes='"
-
-
-    #
-    # -- [[ Anti-Automation / DoS Protection ]] ------------------------------------
-    #
-    # Optional DoS protection against clients making requests too quickly.
-    #
-    # When a client is making more than 100 requests (excluding static files) within
-    # 60 seconds, this is considered a 'burst'. After two bursts, the client is
-    # blocked for 600 seconds.
-    #
-    # Requests to static files are not counted towards DoS; they are listed in the
-    # 'tx.static_extensions' setting, which you can change in this file (see
-    # section "HTTP Policy Settings").
-    #
-    # For a detailed description, see rule file REQUEST-912-DOS-PROTECTION.conf.
-    #
-    # Uncomment this rule to use this feature:
-    #
     #SecAction \
-    # "id:900700,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:'tx.dos_burst_time_slice=60',\
-    #  setvar:'tx.dos_counter_threshold=100',\
-    #  setvar:'tx.dos_block_timeout=600'"
+    #    "id:900400,\
+    #    phase:1,\
+    #    pass,\
+    #    nolog,\
+    #    setvar:tx.sampling_percentage=100"
+
 
 
     #
@@ -746,80 +753,12 @@ data:
     # Uncomment this rule to use this feature:
     #
     #SecAction \
-    # "id:900950,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.crs_validate_utf8_encoding=1"
-
-
-    #
-    # -- [[ Blocking Based on IP Reputation ]] ------------------------------------
-    #
-    # Blocking based on reputation is permanent in the CRS. Unlike other rules,
-    # which look at the individual request, the blocking of IPs is based on
-    # a persistent record in the IP collection, which remains active for a
-    # certain amount of time.
-    #
-    # There are two ways an individual client can become flagged for blocking:
-    # - External information (RBL, GeoIP, etc.)
-    # - Internal information (Core Rules)
-    #
-    # The record in the IP collection carries a flag, which tags requests from
-    # individual clients with a flag named IP.reput_block_flag.
-    # But the flag alone is not enough to have a client blocked. There is also
-    # a global switch named tx.do_reput_block. This is off by default. If you set
-    # it to 1 (=On), requests from clients with the IP.reput_block_flag will
-    # be blocked for a certain duration.
-    #
-    # Variables
-    # ip.reput_block_flag      Blocking flag for the IP collection record
-    # ip.reput_block_reason    Reason (= rule message) that caused to blocking flag
-    # tx.do_reput_block        Switch deciding if we really block based on flag
-    # tx.reput_block_duration  Setting to define the duration of a block
-    #
-    # It may be important to know, that all the other core rules are skipped for
-    # requests, when it is clear that they carry the blocking flag in question.
-    #
-    # Uncomment this rule to use this feature:
-    #
-    #SecAction \
-    # "id:900960,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.do_reput_block=1"
-    #
-    # Uncomment this rule to change the blocking time:
-    # Default: 300 (5 minutes)
-    #
-    #SecAction \
-    # "id:900970,\
-    #  phase:1,\
-    #  nolog,\
-    #  pass,\
-    #  t:none,\
-    #  setvar:tx.reput_block_duration=300"
-
-
-    #
-    # -- [[ Collection timeout ]] --------------------------------------------------
-    #
-    # Set the SecCollectionTimeout directive from the ModSecurity default (1 hour)
-    # to a lower setting which is appropriate to most sites.
-    # This increases performance by cleaning out stale collection (block) entries.
-    #
-    # This value should be greater than or equal to:
-    # tx.reput_block_duration (see section "Blocking Based on IP Reputation") and
-    # tx.dos_block_timeout (see section "Anti-Automation / DoS Protection").
-    #
-    # Ref: https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#wiki-SecCollectionTimeout
-
-    # Please keep this directive uncommented.
-    # Default: 600 (10 minutes)
-    SecCollectionTimeout {{ .Values.worker.config.modsecurity.crs.SecCollectionTimeout}}
+    #    "id:900950,\
+    #    phase:1,\
+    #    pass,\
+    #    t:none,\
+    #    nolog,\
+    #    setvar:tx.crs_validate_utf8_encoding=1"
 
 
     #
@@ -836,7 +775,7 @@ data:
     SecAction \
         "id:900990,\
         phase:1,\
-        nolog,\
         pass,\
         t:none,\
-        setvar:tx.crs_setup_version=332"
+        nolog,\
+        setvar:tx.crs_setup_version=400"

--- a/charts/codesealer/templates/configmap-modsec.yaml
+++ b/charts/codesealer/templates/configmap-modsec.yaml
@@ -11,171 +11,83 @@ metadata:
   {{- end }}
 data:
   modsec.conf: |
-    Include modsecurity/modsecurity.conf
+    Include coreruleset/modsecurity.conf
 
-    # OWASP CRS v3 rules
-    Include modsecurity/crs-setup.conf
-    {{- if .Values.worker.config.modsecurity.rules.rules900.enabled }}
+    # OWASP CRS v4.0.0 rules
+    Include coreruleset/crs-setup.conf
 
-    Include modsecurity/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
-    {{ else }}
-
-    # Include modsecurity/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+    {{- if .Values.worker.waf.rules.rules901 }}
+    Include coreruleset/rules/REQUEST-901-INITIALIZATION.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules901.enabled }}
-
-    Include modsecurity/rules/REQUEST-901-INITIALIZATION.conf
-    {{ else }}
-    
-    # Include modsecurity/rules/REQUEST-901-INITIALIZATION.conf
+    {{- if .Values.worker.waf.rules.rules905 }}
+    Include coreruleset/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules903.enabled }}
-    Include modsecurity/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
-
-    Include modsecurity/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
-    
-    Include modsecurity/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
-    
-    Include modsecurity/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
-    
-    Include modsecurity/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
-    
-    Include modsecurity/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
-    
-    # Include modsecurity/rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
-    
-    # Include modsecurity/rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf
-    
-    # Include modsecurity/rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf
-    
-    # Include modsecurity/rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf
-    
-    # Include modsecurity/rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf
+    {{- if .Values.worker.waf.rules.rules911 }}
+    Include coreruleset/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules905.enabled }}
-    Include modsecurity/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+    {{- if .Values.worker.waf.rules.rules913 }}
+    Include coreruleset/rules/REQUEST-913-SCANNER-DETECTION.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules910.enabled }}
-    Include modsecurity/rules/REQUEST-910-IP-REPUTATION.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-910-IP-REPUTATION.conf
+    {{- if .Values.worker.waf.rules.rules920 }}
+    Include coreruleset/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules911.enabled }}
-    Include modsecurity/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+    {{- if .Values.worker.waf.rules.rules921 }}
+    Include coreruleset/rules/REQUEST-921-PROTOCOL-ATTACK.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules912.enabled }}
-    Include modsecurity/rules/REQUEST-912-DOS-PROTECTION.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-912-DOS-PROTECTION.conf
+    {{- if .Values.worker.waf.rules.rules922 }}
+    Include coreruleset/rules/REQUEST-922-MULTIPART-ATTACK.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules913.enabled }}
-    Include modsecurity/rules/REQUEST-913-SCANNER-DETECTION.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-913-SCANNER-DETECTION.conf
+    {{- if .Values.worker.waf.rules.rules930 }}
+    Include coreruleset/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules920.enabled }}
-    Include modsecurity/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf
+    {{- if .Values.worker.waf.rules.rules931 }}
+    Include coreruleset/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules921.enabled }}
-    Include modsecurity/rules/REQUEST-921-PROTOCOL-ATTACK.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-921-PROTOCOL-ATTACK.conf
+    {{- if .Values.worker.waf.rules.rules932 }}
+    Include coreruleset/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules930.enabled }}
-    Include modsecurity/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf
+    {{- if .Values.worker.waf.rules.rules933 }}
+    Include coreruleset/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules932.enabled }}
-    Include modsecurity/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf
+    {{- if .Values.worker.waf.rules.rules934 }}
+    Include coreruleset/rules/REQUEST-934-APPLICATION-ATTACK-GENERIC.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules932.enabled }}
-    Include modsecurity/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf
+    {{- if .Values.worker.waf.rules.rules941 }}
+    Include coreruleset/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules933.enabled }}
-    Include modsecurity/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf
+    {{- if .Values.worker.waf.rules.rules942 }}
+    Include coreruleset/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules934.enabled }}
-    Include modsecurity/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf
+    {{- if .Values.worker.waf.rules.rules943 }}
+    Include coreruleset/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules941.enabled }}
-    Include modsecurity/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf
+    {{- if .Values.worker.waf.rules.rules944 }}
+    Include coreruleset/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules942.enabled }}
-    Include modsecurity/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf
+    {{- if .Values.worker.waf.rules.rules949 }}
+    Include coreruleset/rules/REQUEST-949-BLOCKING-EVALUATION.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules943.enabled }}
-    Include modsecurity/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf
+    {{- if .Values.worker.waf.rules.rules950 }}
+    Include coreruleset/rules/RESPONSE-950-DATA-LEAKAGES.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules944.enabled }}
-    Include modsecurity/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf
+    {{- if .Values.worker.waf.rules.rules951 }}
+    Include coreruleset/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules949.enabled }}
-    Include modsecurity/rules/REQUEST-949-BLOCKING-EVALUATION.conf
-    {{ else }}
-    # Include modsecurity/rules/REQUEST-949-BLOCKING-EVALUATION.conf
+    {{- if .Values.worker.waf.rules.rules952 }}
+    Include coreruleset/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules950.enabled }}
-    Include modsecurity/rules/RESPONSE-950-DATA-LEAKAGES.conf
-    {{ else }}
-    # Include modsecurity/rules/RESPONSE-950-DATA-LEAKAGES.conf
+    {{- if .Values.worker.waf.rules.rules953 }}
+    Include coreruleset/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules951.enabled }}
-    Include modsecurity/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
-    {{ else }}
-    # Include modsecurity/rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf
+    {{- if .Values.worker.waf.rules.rules954 }}
+    Include coreruleset/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules952.enabled }}
-    Include modsecurity/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
-    {{ else }}
-    # Include modsecurity/rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf
+    {{- if .Values.worker.waf.rules.rules955 }}
+    Include coreruleset/rules/RESPONSE-955-WEB-SHELLS.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules953.enabled }}
-    Include modsecurity/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
-    {{ else }}
-    # Include modsecurity/rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf
+    {{- if .Values.worker.waf.rules.rules959 }}
+    Include coreruleset/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
     {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules954.enabled }}
-    Include modsecurity/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
-    {{ else }}
-    # Include modsecurity/rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf
-    {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules959.enabled }}
-    Include modsecurity/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
-    {{ else }}
-    # Include modsecurity/rules/RESPONSE-959-BLOCKING-EVALUATION.conf
-    {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules980.enabled }}
-    Include modsecurity/rules/RESPONSE-980-CORRELATION.conf
-    {{ else }}
-    # Include modsecurity/rules/RESPONSE-980-CORRELATION.conf
-    {{- end }}
-    {{- if .Values.worker.config.modsecurity.rules.rules999.enabled }}
-    Include modsecurity/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
-    {{ else }}
-    # Include modsecurity/rules/RESPONSE-999-EXCLUSION-RULES-AFTER-CRS.conf
+    {{- if .Values.worker.waf.rules.rules980 }}
+    Include coreruleset/rules/RESPONSE-980-CORRELATION.conf
     {{- end }}

--- a/charts/codesealer/templates/configmap-modsecurity.yaml
+++ b/charts/codesealer/templates/configmap-modsecurity.yaml
@@ -17,7 +17,7 @@ data:
     # only to start with, because that minimises the chances of post-installation
     # disruption.
     #
-    SecRuleEngine {{ .Values.worker.config.modsecurity.SecRuleEngine }}
+    SecRuleEngine {{ .Values.worker.waf.SecRuleEngine }}
 
 
     # -- Request body handling ---------------------------------------------------
@@ -26,27 +26,27 @@ data:
     # won't be able to see any POST parameters, which opens a large security
     # hole for attackers to exploit.
     #
-    SecRequestBodyAccess {{ .Values.worker.config.modsecurity.SecRequestBodyAccess }}
+    SecRequestBodyAccess {{ .Values.worker.waf.SecRequestBodyAccess }}
 
 
     # Enable XML request body parser.
     # Initiate XML Processor in case of xml content-type
     #
-    SecRule REQUEST_HEADERS:Content-Type "(?:application(?:/soap\+|/)|text/)xml" \
-          "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
+    SecRule REQUEST_HEADERS:Content-Type "^(?:application(?:/soap\+|/)|text/)xml" \
+         "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
 
     # Enable JSON request body parser.
     # Initiate JSON Processor in case of JSON content-type; change accordingly
     # if your application does not use 'application/json'
     #
-    SecRule REQUEST_HEADERS:Content-Type "application/json" \
-          "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
+    SecRule REQUEST_HEADERS:Content-Type "^application/json" \
+         "id:'200001',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
     # Sample rule to enable JSON request body parser for more subtypes.
     # Uncomment or adapt this rule if you want to engage the JSON
     # Processor for "+json" subtypes
     #
-    #SecRule REQUEST_HEADERS:Content-Type "^application/.+[+]json$" \
+    #SecRule REQUEST_HEADERS:Content-Type "^application/[a-z0-9.-]+[+]json" \
     #     "id:'200006',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=JSON"
 
     # Maximum request body size we will accept for buffering. If you support
@@ -55,15 +55,30 @@ data:
     # to the size of data, with files excluded. You want to keep that value as
     # low as practical.
     #
-    SecRequestBodyLimit {{ .Values.worker.config.modsecurity.SecRequestBodyLimit }}
-    SecRequestBodyNoFilesLimit {{ .Values.worker.config.modsecurity.SecRequestBodyNoFilesLimit }}
+    SecRequestBodyLimit {{ .Values.worker.waf.SecRequestBodyLimit }}
+    SecRequestBodyNoFilesLimit {{ .Values.worker.waf.SecRequestBodyNoFilesLimit }}
 
     # What to do if the request body size is above our configured limit.
     # Keep in mind that this setting will automatically be set to ProcessPartial
     # when SecRuleEngine is set to DetectionOnly mode in order to minimize
     # disruptions when initially deploying ModSecurity.
     #
-    SecRequestBodyLimitAction {{ .Values.worker.config.modsecurity.SecRequestBodyLimitAction }}
+    SecRequestBodyLimitAction {{ .Values.worker.waf.SecRequestBodyLimitAction }}
+
+    # Maximum parsing depth allowed for JSON objects. You want to keep this
+    # value as low as practical.
+    #
+    SecRequestBodyJsonDepthLimit 512
+
+    # Maximum number of args allowed per request. You want to keep this
+    # value as low as practical. The value should match that in rule 200007.
+    SecArgumentsLimit 1000
+
+    # If SecArgumentsLimit has been set, you probably want to reject any
+    # request body that has only been partly parsed. The value used in this
+    # rule should match what was used with SecArgumentsLimit
+    SecRule &ARGS "@ge 1000" \
+    "id:'200007', phase:2,t:none,log,deny,status:400,msg:'Failed to fully parse request body due to large argument count',severity:2"
 
     # Verify that we've correctly processed the request body.
     # As a rule of thumb, when failing to process a request body
@@ -139,7 +154,7 @@ data:
     # MULTIPART_UNMATCHED_BOUNDARY.
     #
     SecRule MULTIPART_UNMATCHED_BOUNDARY "@eq 1" \
-          "id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
+        "id:'200004',phase:2,t:none,log,deny,msg:'Multipart parser detected a possible unmatched boundary.'"
 
 
     # PCRE Tuning
@@ -154,47 +169,47 @@ data:
     # MSC_PCRE_LIMITS_EXCEEDED: PCRE match limits were exceeded.
     #
     SecRule TX:/^MSC_/ "!@streq 0" \
-                "id:'200005',phase:2,t:none,deny,msg:'ModSecurity internal error flagged: %{MATCHED_VAR_NAME}'"
+            "id:'200005',phase:2,t:none,deny,msg:'ModSecurity internal error flagged: %{MATCHED_VAR_NAME}'"
 
 
     # -- Response body handling --------------------------------------------------
 
-    # Allow ModSecurity to access response bodies. 
+    # Allow ModSecurity to access response bodies.
     # You should have this directive enabled in order to identify errors
     # and data leakage issues.
-    # 
+    #
     # Do keep in mind that enabling this directive does increases both
     # memory consumption and response latency.
     #
-    SecResponseBodyAccess {{ .Values.worker.config.modsecurity.SecResponseBodyAccess }}
+    SecResponseBodyAccess {{ .Values.worker.waf.SecResponseBodyAccess }}
 
     # Which response MIME types do you want to inspect? You should adjust the
     # configuration below to catch documents but avoid static files
     # (e.g., images and archives).
     #
-    SecResponseBodyMimeType text/plain text/html text/xml text/json
+    SecResponseBodyMimeType text/plain text/html text/xml
 
     # Buffer response bodies of up to 512 KB in length.
-    SecResponseBodyLimit {{ .Values.worker.config.modsecurity.SecResponseBodyLimit }}
+    SecResponseBodyLimit {{ .Values.worker.waf.SecResponseBodyLimit }}
 
     # What happens when we encounter a response body larger than the configured
     # limit? By default, we process what we have and let the rest through.
     # That's somewhat less secure, but does not break any legitimate pages.
     #
-    SecResponseBodyLimitAction {{ .Values.worker.config.modsecurity.SecResponseBodyLimitAction }}
+    SecResponseBodyLimitAction {{ .Values.worker.waf.SecResponseBodyLimitAction }}
 
 
     # -- Filesystem configuration ------------------------------------------------
 
     # The location where ModSecurity stores temporary files (for example, when
     # it needs to handle a file upload that is larger than the configured limit).
-    # 
-    # This default setting is chosen due to all systems have /tmp available however, 
+    #
+    # This default setting is chosen due to all systems have /tmp available however,
     # this is less than ideal. It is recommended that you specify a location that's private.
     #
     SecTmpDir /tmp/
 
-    # The location where ModSecurity will keep its persistent data.  This default setting 
+    # The location where ModSecurity will keep its persistent data.  This default setting
     # is chosen due to all systems have /tmp available however, it
     # too should be updated to a place that other users can't access.
     #
@@ -227,22 +242,21 @@ data:
     # The default debug log configuration is to duplicate the error, warning
     # and notice messages from the error log.
     #
-    #SecDebugLog /opt/modsecurity/var/log/debug.log
     SecDebugLog /dev/stdout
-    #SecDebugLogLevel {{ .Values.worker.config.modsecurity.SecDebugLogLevel }}
+    SecDebugLogLevel {{ .Values.worker.waf.SecDebugLogLevel }}
 
 
     # -- Audit log configuration -------------------------------------------------
 
     # Log the transactions that are marked by a rule, as well as those that
-    # trigger a server error (determined by a 5xx or 4xx, excluding 404,  
+    # trigger a server error (determined by a 5xx or 4xx, excluding 404,
     # level response status codes).
     #
-    SecAuditEngine {{ .Values.worker.config.modsecurity.SecAuditEngine }}
-    SecAuditLogRelevantStatus {{ .Values.worker.config.modsecurity.SecAuditLogRelevantStatus | quote }}
+    SecAuditEngine {{ .Values.worker.waf.SecAuditEngine }}
+    SecAuditLogRelevantStatus {{ .Values.worker.waf.SecAuditLogRelevantStatus | quote }}
 
     # Log everything we know about a transaction.
-    SecAuditLogParts {{ .Values.worker.config.modsecurity.SecAuditLogParts }}
+    SecAuditLogParts {{ .Values.worker.waf.SecAuditLogParts }}
 
     # Use a single file for logging. This is much easier to look at, but
     # assumes that you will use the audit log only ocassionally.
@@ -280,4 +294,4 @@ data:
     # The following information will be shared: ModSecurity version,
     # Web Server version, APR version, PCRE version, Lua version, Libxml2
     # version, Anonymous unique id for host.
-    SecStatusEngine {{ .Values.worker.config.modsecurity.SecStatusEngine }}
+    SecStatusEngine On

--- a/charts/codesealer/values.yaml
+++ b/charts/codesealer/values.yaml
@@ -185,223 +185,122 @@ worker:
       # The maximum total size of the cache, in bytes.
       maxSize: 0
 
-    ################################################
-    #                 WAF settings                 #
-    ################################################
-    modsecurity:
-      # Enable ModSecurity, attaching it to every transaction. Use detection
-      # only to start with, because that minimises the chances of post-installation
-      # disruption.
-      # Values: 'On', 'Off', or 'Detection Only'
-      SecRuleEngine: "On"
-      # Allow ModSecurity to access request bodies. If you don't, ModSecurity
-      # won't be able to see any POST parameters, which opens a large security
-      # hole for attackers to exploit.
-      #
-      SecRequestBodyAccess: "On"
-      # Maximum request body size we will accept for buffering. If you support
-      # file uploads then the value given on the first line has to be as large
-      # as the largest file you are willing to accept. The second value refers
-      # to the size of data, with files excluded. You want to keep that value as
-      # low as practical.
-      SecRequestBodyLimit: "13107200"
-      SecRequestBodyNoFilesLimit: "131072"
-      # What to do if the request body size is above our configured limit.
-      # Keep in mind that this setting will automatically be set to ProcessPartial
-      # when SecRuleEngine is set to DetectionOnly mode in order to minimize
-      # disruptions when initially deploying ModSecurity.
-      # Values: Reject or ProcessPartial
-      SecRequestBodyLimitAction: Reject
-      # Allow ModSecurity to access response bodies.
-      # You should have this directive enabled in order to identify errors
-      # and data leakage issues.
-      # Do keep in mind that enabling this directive does increases both
-      # memory consumption and response latency.
-      SecResponseBodyAccess: "On"
-      # Buffer response bodies of up to 512 KB in length.
-      SecResponseBodyLimit: "524288"
-      # What happens when we encounter a response body larger than the configured
-      # limit? By default, we process what we have and let the rest through.
-      # That's somewhat less secure, but does not break any legitimate pages.
-      SecResponseBodyLimitAction: ProcessPartial
-      # The default debug log configuration is to duplicate the error, warning
-      # and notice messages from the error log.
-      SecDebugLogLevel: 3
-      # Log the transactions that are marked by a rule, as well as those that
-      # trigger a server error (determined by a 5xx or 4xx, excluding 404,
-      # level response status codes).
-      # Values: Off, RelevantOnly
-      SecAuditEngine: "Off"
-      SecAuditLogRelevantStatus: "^(?:5|4(?!04))"
-      # Log everything we know about a transaction.
-      SecAuditLogParts: ABIJDEFHZ
-      # Improve the quality of ModSecurity by sharing information about your
-      # current ModSecurity version and dependencies versions.
-      # The following information will be shared: ModSecurity version,
-      # Web Server version, APR version, PCRE version, Lua version, Libxml2
-      # version, Anonymous unique id for host.
-      SecStatusEngine: "Off"
+  ################################################
+  #                 WAF settings                 #
+  ################################################
+  waf:
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#user-content-SecRuleEngine
+    SecRuleEngine: "On"
 
-      crs:
-        # The Paranoia Level (PL) setting allows you to choose the desired level
-        # of rule checks that will add to your anomaly scores.
-        paranoiaLevel: 1
-        # It is possible to execute rules from a higher paranoia level but not include
-        # them in the anomaly scoring. This allows you to take a well-tuned system on
-        # paranoia level 1 and add rules from paranoia level 2 without having to fear
-        # the new rules would lead to false positives that raise your score above the
-        # threshold.
-        executing_paranoia_level: 1
-        # ModSecurity selects the body processor based on the Content-Type request
-        # header. But clients are not always setting the Content-Type header for their
-        # request body payloads. This will leave ModSecurity with limited vision into
-        # the payload.  The variable tx.enforce_bodyproc_urlencoded lets you force the
-        # URLENCODED body processor in these situations. This is off by default, as it
-        # implies a change of the behaviour of ModSecurity beyond CRS (the body
-        # processor applies to all rules, not only CRS) and because it may lead to
-        # false positives already on paranoia level 1. However, enabling this variable
-        # closes a possible bypass of CRS so it should be considered.
-        enforce_bodyproc_urlencoded: 0
-        # Each rule in the CRS has an associated severity level.
-        # These are the default scoring points for each severity level.
-        # These settings will be used to increment the anomaly score if a rule matches.
-        # You may adjust these points to your liking, but this is usually not needed.
-        # - CRITICAL severity: Anomaly Score of 5.
-        #       Mostly generated by the application attack rules (93x and 94x files).
-        # - ERROR severity: Anomaly Score of 4.
-        #       Generated mostly from outbound leakage rules (95x files).
-        # - WARNING severity: Anomaly Score of 3.
-        #       Generated mostly by malicious client rules (91x files).
-        # - NOTICE severity: Anomaly Score of 2.
-        #       Generated mostly by the protocol rules (92x files).
-        critical_anomaly_score: 5
-        error_anomaly_score: 4
-        warning_anomaly_score: 3
-        notice_anomaly_score: 2
-        # Here, you can specify at which cumulative anomaly score an inbound request,
-        # or outbound response, gets blocked.
-        # Most detected inbound threats will give a critical score of 5.
-        # Smaller violations, like violations of protocol/standards, carry lower scores.
-        inbound_anomaly_score_threshold: 5
-        outbound_anomaly_score_threshold: 4
-        # Set the SecCollectionTimeout directive from the ModSecurity default (1 hour)
-        # to a lower setting which is appropriate to most sites.
-        # This increases performance by cleaning out stale collection (block) entries.
-        SecCollectionTimeout: 600
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#user-content-SecRequestBodyAccess
+    SecRequestBodyAccess: "On"
 
-      rules:
-        # EXCLUSION-RULES-BEFORE-CRS
-        rules900:
-          enabled: false
-          tags: []
-        # INITIALIZATION
-        rules901:
-          enabled: true
-          tags: []
-        # EXCLUSION-RULES
-        rules903:
-          enabled: true
-          tags: []
-        # COMMON-EXCEPTIONS
-        rules905:
-          enabled: true
-          tags: ["attack-generic", "language-multi"]
-        # IP-REPUTATION
-        rules910:
-          enabled: true
-          tags: []
-        # METHOD-ENFORCEMENT
-        rules911:
-          enabled: true
-          tags: ["attack-generic", "language-multi"]
-        # DOS-PROTECTION
-        rules912:
-          enabled: true
-          tags: []
-        # SCANNER-DETECTION.
-        rules913:
-          enabled: true
-          tags: ["attack-reputation-scanner", "language-multi"]
-        # PROTOCOL-ENFORCEMENT
-        rules920:
-          enabled: true
-          tags: ["platform-iis", "platform-windows", "attack-protocol", "language-aspnet", "language-multi"]
-        # PROTOCOL-ATTACK
-        rules921:
-          enabled: true
-          tags: ["platform-apache", "attack-protocol", "language-ldap", "language-multi"]
-        # APPLICATION-ATTACK-LFI
-        rules930:
-          enabled: true
-          tags: ["language-multi"]
-        # APPLICATION-ATTACK-RFI
-        rules931:
-          enabled: true
-          tags: ["attack-rfi", "language-multi"]
-        # APPLICATION-ATTACK-RCE
-        rules932:
-          enabled: true
-          tags: ["platform-unix", "platform-windows", "attack-rce", "language-multi", "language-powershell", "language-shell"]
-        # APPLICATION-ATTACK-PHP
-        rules933:
-          enabled: true
-          tags: ["attack-injection-php", "language-php"]
-        # APPLICATION-ATTACK-NODEJS
-        rules934:
-          enabled: true
-          tags: ["attack-generic", "attack-injection-generic", "attack-ssrf", "attack-rce", "language-javascript", "language-multi", "language-perl", "language-php", "language-ruby"]
-        # APPLICATION-ATTACK-XSS
-        rules941:
-          enabled: true
-          tags: ["platform-ie", "platform-tomcat", "attack-xss", "language-multi"]
-        # APPLICATION-ATTACK-SQLI
-        rules942:
-          enabled: true
-          tags: ["platform-sql", "attack-sqli", "language-multi"]
-        # APPLICATION-ATTACK-SESSION-FIXATION
-        rules943:
-          enabled: true
-          tags: ["attack-fixation", "language-multi"]
-        # APPLICATION-ATTACK-JAVA
-        rules944:
-          enabled: true
-          tags: ["attack-injection-java", "attack-rce", "language-java"]
-        # BLOCKING-EVALUATION
-        rules949:
-          enabled: true
-          tags: []
-        # BDATA-LEAKAGES
-        rules950:
-          enabled: true
-          tags: ["language-multi"]
-        # DATA-LEAKAGES
-        rules951:
-          enabled: true
-          tags: ["platform-db", "platform-sql", "attack-disclosure", "language-multi"]
-        # DATA-LEAKAGES
-        rules952:
-          enabled: true
-          tags: ["language-java"]
-        # DATA-LEAKAGES
-        rules953:
-          enabled: true
-          tags: ["language-php"]
-        # DATA-LEAKAGES
-        rules954:
-          enabled: true
-          tags: ["platform-iie", "platform-windows", "language-multi"]
-        # BLOCKING-EVALUATION
-        rules959:
-          enabled: true
-          tags: []
-        # CORRELATION
-        rules980:
-          enabled: true
-          tags: []
-        # EXCLUSION-RULES-AFTER-CRS
-        rules999:
-          enabled: false
-          tags: []
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secrequestbodylimit
+    SecRequestBodyLimit: "13107200"
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secrequestbodynofileslimit
+    SecRequestBodyNoFilesLimit: "131072"
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secrequestbodylimitaction
+    SecRequestBodyLimitAction: Reject
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secresponsebodyaccess
+    SecResponseBodyAccess: "On"
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secresponsebodylimit
+    SecResponseBodyLimit: "524288"
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secresponsebodylimitaction
+    SecResponseBodyLimitAction: ProcessPartial
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secdebugloglevel
+    SecDebugLogLevel: 0
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#user-content-SecAuditEngine
+    SecAuditEngine: "Off"
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#secauditlogrelevantstatus
+    SecAuditLogRelevantStatus: "^(?:5|4(?!04))"
+
+    # https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v3.x)#user-content-SecAuditLogParts
+    SecAuditLogParts: ABIJDEFHZ
+
+    crs:
+      # https://coreruleset.org/docs/concepts/paranoia_levels/
+      blocking_paranoia_level: 1
+      detection_paranoia_level: 1
+
+      # ModSecurity selects the body processor based on the Content-Type request
+      # header. But clients are not always setting the Content-Type header for their
+      # request body payloads. This will leave ModSecurity with limited vision into
+      # the payload.  The variable tx.enforce_bodyproc_urlencoded lets you force the
+      # URLENCODED body processor in these situations. This is off by default, as it
+      # implies a change of the behaviour of ModSecurity beyond CRS (the body
+      # processor applies to all rules, not only CRS) and because it may lead to
+      # false positives already on paranoia level 1. However, enabling this variable
+      # closes a possible bypass of CRS so it should be considered.
+      enforce_bodyproc_urlencoded: 0
+
+      # https://coreruleset.org/docs/concepts/anomaly_scoring/
+      critical_anomaly_score: 5
+      error_anomaly_score: 4
+      warning_anomaly_score: 3
+      notice_anomaly_score: 2
+      inbound_anomaly_score_threshold: 5
+      outbound_anomaly_score_threshold: 4
+
+    # https://coreruleset.org/docs/rules/rules/
+    rules:
+      # Request: Initialization
+      rules901: true
+      # Request: Common Exceptions
+      rules905: true
+      # Request: Method Enforcement
+      rules911: false
+      # Request: Scanner Detection
+      rules913: true
+      # Request: Protocol Enforcement
+      rules920: false
+      # Request: Protocol Attack
+      rules921: true
+      # Request: Multipart Attack
+      rules922: false
+      # Request: Application Attack LFI
+      rules930: true
+      # Request: Application Attack RFI
+      rules931: false
+      # Request: Application Attack RCE
+      rules932: false
+      # Request: Application Attack PHP
+      rules933: false
+      # Request: Application Attack Generic
+      rules934: false
+      # Request: Application Attack XSS
+      rules941: true
+      # Request: Application Attack SQLi
+      rules942: true
+      # Request: Application Attack Session Fixation
+      rules943: true
+      # Request: Application Attack Java
+      rules944: false
+      # Request: Blocking Evaluation
+      rules949: true
+      # Response: Data Leakages
+      rules950: false
+      # Response: Data Leakages SQL
+      rules951: false
+      # Response: Data Leakages Java
+      rules952: false
+      # Response: Data Leakages PHP
+      rules953: false
+      # Response: Data Leakages IIS
+      rules954: false
+      # Response: Web Shells
+      rules955: false
+      # Response: Blocking Evaluation
+      rules959: false
+      # Response: Correlation
+      rules980: false
 
 ###################################
 ##        Manager settings       ##


### PR DESCRIPTION
* Updated the modsec/CRS config maps to match CRS v4. 
* Cleaned up the WAF configuration in `values.yaml`.
* Adjusted the rules included by default.

We should hold off on merging this until the docker images are updated.