### PR TITLE
Update path to core rulset files

### DIFF
--- a/charts/codesealer/Chart.yaml
+++ b/charts/codesealer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/codesealer/templates/codesealer-worker-deployment.yaml
+++ b/charts/codesealer/templates/codesealer-worker-deployment.yaml
@@ -42,10 +42,10 @@ spec:
               mountPath: /etc/codesealer-core/modsec.conf
               subPath: modsec.conf
             - name: modsecurity-conf
-              mountPath: /etc/codesealer-core/modsecurity/modsecurity.conf
+              mountPath: /etc/codesealer-core/coreruleset/modsecurity.conf
               subPath: modsecurity.conf
             - name: crs-setup-conf
-              mountPath: /etc/codesealer-core/modsecurity/crs-setup.conf
+              mountPath: /etc/codesealer-core/coreruleset/crs-setup.conf
               subPath: crs-setup.conf
           env:
           - name: REDIS_PASSWORD

--- a/charts/codesealer/templates/configmap-patch.yaml
+++ b/charts/codesealer/templates/configmap-patch.yaml
@@ -50,10 +50,10 @@ data:
               mountPath: /etc/codesealer-core/modsec.conf
               subPath: modsec.conf
             - name: modsecurity-conf
-              mountPath: /etc/codesealer-core/modsecurity/modsecurity.conf
+              mountPath: /etc/codesealer-core/coreruleset/modsecurity.conf
               subPath: modsecurity.conf
             - name: crs-setup-conf
-              mountPath: /etc/codesealer-core/modsecurity/crs-setup.conf
+              mountPath: /etc/codesealer-core/coreruleset/crs-setup.conf
               subPath: crs-setup.conf
           env:
           - name: REDIS_PASSWORD


### PR DESCRIPTION
The path was updated [here](https://github.com/code-sealer/codesealer-core/commit/2e88a05e238dc35357b0e2ed3981861493e372bc), but the change wasn't carried over to the helm chart.